### PR TITLE
HWKAPM-781 - Added support for OpenTracing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM ryanj/centos7-nodejs:6.4.0
-# The parent image uses ONBUILD to add package.json, run npm install and add bonjour.js
-# See https://github.com/ryanj/origin-s2i-nodejs/blob/master/nodejs.org/Dockerfile.onbuild#L65
-ENV ZIPKIN_SERVER_URL="http://zipkin-query:9411"
+
+ENV ENABLE_ZIPKIN false
+ENV ZIPKIN_SERVER_URL http://zipkin-query:9411

--- a/bonjour.js
+++ b/bonjour.js
@@ -35,7 +35,7 @@ app.use(session({
   store: memoryStore
 }));
 
-// Use our zipkin integration
+console.log("Using ZipKin for distributed tracing.");
 app.use(zipkin);
 
 // Enable CORS

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express-session": "^1.14.2",
     "keycloak-auth-utils": "2.4.0",
     "keycloak-connect": "^2.4.0",
+    "opentracing": "^0.13.0",
     "opossum": "~0.1.1",
     "roi": "~0.13.0",
     "zipkin": "^0.2.5",


### PR DESCRIPTION
@objectiser , @pavolloffay , @rafabene could you please review? Note that the changes from this PR should be merged around the same time as similar changes for the other modules.

I added two more commits to this: the second commit is something I had to do here to get this module working, but is not related to opentracing at all. I'm wondering if you also need it? 
The last change is to fix something I've missed on the first :) I set the port of bonjour to 8180 locally, to make it easier to test all services directly on bare metal, instead of openshift. 