### PR TITLE
keycloak-auth-utils should be in the package.json.  #10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "es6-shim": "^0.35.1",
     "express": "^4.13.4",
     "express-session": "^1.14.2",
+    "keycloak-auth-utils": "^2.5.0",
     "keycloak-connect": "^2.4.0",
     "zipkin": "^0.2.5",
     "zipkin-context-cls": "^0.2.1",


### PR DESCRIPTION
For issue #10 .  

i wasn't sure what version to use, so using the latest,  i noticed that when installing, keycloak-connect does get 2.5.0 instead of 2.4.0 but thats becuase of that `^`