### PR TITLE
refactoring the way routes are setup.

### DIFF
--- a/bonjour.js
+++ b/bonjour.js
@@ -45,7 +45,7 @@ app.use((req, res, next) => {
   next();
 });
 
-app.use('/api', api.secure(memoryStore));
+app.use('/api', api.routes(memoryStore));
 
 // default route (should be swagger)
 app.get('/', (req, res) => res.send('Logged out'));

--- a/lib/api.js
+++ b/lib/api.js
@@ -16,6 +16,7 @@
  */
 
 const os = require('os');
+const fs = require('fs');
 
 const express = require('express');
 const router = express.Router();
@@ -29,12 +30,6 @@ const Keycloak = require('keycloak-connect');
 
 // business logic
 const sayBonjour = () => `Bonjour de ${os.hostname()}`;
-
-router.get('/bonjour', (req, resp) => resp.type('text/plain').send(sayBonjour()));
-
-router.get('/health', (req, resp) => {
-  resp.type('text/plain').send('I am ok');
-});
 
 // circuit breaker
 const circuitOptions = {
@@ -51,16 +46,22 @@ function fallback () {
 const circuit = circuitBreaker(roi.get, circuitOptions);
 circuit.fallback(fallback);
 
-router.get('/bonjour-chaining', (req, resp) =>
-  circuit.fire({endpoint: `http://${nextService}:8080/api/${nextService}-chaining`}).then((response) => {
-    resp.set('Access-Control-Allow-Origin', '*');
-    resp.type('application/json').send(response);
-  }).catch((e) => resp.send(e))
-);
+// Define routes
+router.routes = (store) => {
+  router.get('/bonjour', (req, resp) => resp.type('text/plain').send(sayBonjour()));
 
-router.secure = (store) => {
+  router.get('/health', (req, resp) => {
+    resp.type('text/plain').send('I am ok');
+  });
+
+  router.get('/bonjour-chaining', (req, resp) =>
+    circuit.fire({endpoint: `http://${nextService}:8080/api/${nextService}-chaining`}).then((response) => {
+      resp.set('Access-Control-Allow-Origin', '*');
+      resp.type('application/json').send(response);
+    }).catch((e) => resp.send(e))
+  );
+
   // Configure keycloak based on keycloak.json and the KEYCLOAK_AUTH_SERVER_URL env var
-  const fs = require('fs');
   const customKeyCloakConfig = JSON.parse(fs.readFileSync(`${__dirname}/keycloak.json`).toString());
   customKeyCloakConfig.authServerUrl = process.env.KEYCLOAK_AUTH_SERVER_URL;
   const keycloak = new Keycloak({ scope: 'USERS', store }, customKeyCloakConfig);


### PR DESCRIPTION
Motivation:  api.secure() made it feel like we are only setting up the secure routes, when in fact,
all the routes for the api are returned. I've renamed the function routes instead, as i feel it more
accuratly describes what is being setup and returned.

This is more a preference thing