### PR TITLE
Update docker image to our new official community version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ryanj/centos7-nodejs:6.4.0
+FROM bucharestgold/centos7-nodejs:6.9.5
 # The parent image uses ONBUILD to add package.json, run npm install and add bonjour.js
 # See https://github.com/ryanj/origin-s2i-nodejs/blob/master/nodejs.org/Dockerfile.onbuild#L65
 ENV ZIPKIN_SERVER_URL="http://zipkin-query:9411"


### PR DESCRIPTION
We(the node team) have taken ownership of the community s2i images that ryan previously had created,  Now that we have publish them under our new org on dockerhub, this updates the image being used.