### PR TITLE
update FROM to centos7-s2i-nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM bucharestgold/centos7-nodejs:latest
+FROM bucharestgold/centos7-s2i-nodejs:latest
 # The parent image uses ONBUILD to add package.json, run npm install and add bonjour.js
 # See https://github.com/ryanj/origin-s2i-nodejs/blob/master/nodejs.org/Dockerfile.onbuild#L65


### PR DESCRIPTION
The centos7-nodejs repo is no longer supported.